### PR TITLE
state: Use redux for more changes

### DIFF
--- a/src/features/imports/Page.tsx
+++ b/src/features/imports/Page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, createRef } from "react";
+import { useEffect, useState, createRef, useCallback } from "react";
 import classnames from "classnames/bind";
 import axios from "axios";
 import { saveAs } from 'file-saver';
@@ -370,11 +370,11 @@ export const ImportPage = (props: ImportPageProps) => {
           </Row>
           {state.loaded && currentImport ?
             statements.map((statement, idx) => (
-              <Statement
-                key={statement.id}
-                statement={statement}
-                database={currentImport.database}
-                idx={idx}
+              <Statement 
+                key={statement.id} 
+                idx={idx} 
+                importId={importId}
+                statementId={statement.id}
                 ref={state.statementRefs[idx]}
                 callbacks={{
                   handleFixSequence: handleFixSequence,

--- a/src/features/imports/Page.tsx
+++ b/src/features/imports/Page.tsx
@@ -101,14 +101,6 @@ export const ImportPage = (props: ImportPageProps) => {
     )
   };
 
-  const handleTextAreaChangeForIdx = (idx: number, event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const newState = state.data;
-    newState.import_metadata.statements[idx].cockroach = event.target.value;
-    setState({...state, data: newState});
-  }
-
-  const handleTextAreaChange = (idx: number) => (event: React.ChangeEvent<HTMLTextAreaElement>) => handleTextAreaChangeForIdx(idx, event);
-
   const handleFixSequence = (statementIdx: number, issueIdentifier: string) => {
     axios.post<ImportStatement>(
       "http://" + window.location.hostname + ":5050/fix_sequence",
@@ -385,7 +377,6 @@ export const ImportPage = (props: ImportPageProps) => {
                 idx={idx}
                 ref={state.statementRefs[idx]}
                 callbacks={{
-                  handleTextAreaChange: handleTextAreaChange(idx),
                   handleFixSequence: handleFixSequence,
                   setActiveStatement: () => setActiveStatement(idx),
                 }}

--- a/src/features/imports/Page.tsx
+++ b/src/features/imports/Page.tsx
@@ -269,7 +269,7 @@ export const ImportPage = (props: ImportPageProps) => {
     }
   }
 
-  const findAndReplace = (args: FindAndReplaceArgs) => {
+  const findAndReplace = useCallback((args: FindAndReplaceArgs) => {
     if (args.find !== '') {
       var re : (RegExp | null) = null;
       try {
@@ -277,24 +277,25 @@ export const ImportPage = (props: ImportPageProps) => {
       } catch {
         return;
       }
-      const newState = state.data;
-      state.data.import_metadata.statements.forEach((statement, idx) => {
-        if (args.isRegex) {
-          if (re == null) {
-            alert("invalid regexp");
-            return;
-          }
-          state.data.import_metadata.statements[idx].cockroach =
-            state.data.import_metadata.statements[idx].cockroach.replace(re, args.replace);
-        } else {
-          state.data.import_metadata.statements[idx].cockroach =
-            state.data.import_metadata.statements[idx].cockroach.replace(args.find, args.replace);
-        }
+      if (args.isRegex && re == null) {
+        alert("invalid regexp");
+        return;
+      }
+
+      statements.forEach((statement) => {
+        let replaced = args.isRegex
+          ? statement.cockroach.replace(re!, args.replace)
+          : statement.cockroach.replace(args.find, args.replace);
+        dispatch(
+          importsSlice.actions.setStatementText({
+            statement,
+            cockroach: replaced,
+          }),
+        );
       });
-      setState({...supplyRefs({...state, data: newState}), activeStatement: state.activeStatement});
     }
     setFindAndReplace(false);
-  };
+  }, [dispatch, statements]);
 
   const handleSelectAction = (key: string | null) => {
     if (key == null) {

--- a/src/features/imports/components/Statement.tsx
+++ b/src/features/imports/components/Statement.tsx
@@ -2,15 +2,15 @@ import React, { useCallback, useEffect, useState } from "react";
 import { Row, Col, Button, ButtonGroup } from 'react-bootstrap';
 
 import type { ImportIssue } from "../../../common/import";
-import { getSelectorsForImportId, importsSlice, Statement as StatementType } from "../importsSlice";
+import { getSelectorsForImportId, importsSelectors, importsSlice, Statement as StatementType } from "../importsSlice";
 import { modalSlice } from "../../modals/modalSlice";
 import { useAppDispatch, useAppSelector } from "../../../app/hooks";
 import { useAddUser } from "../hooks";
 
 interface StatementProps {
-  statement: StatementType;
   idx: number;
-  database: string;
+  statementId: string;
+  importId: string;
   callbacks: {
     handleFixSequence: (statementIdx: number, issueIdentifier: string) => void;
     setActiveStatement: () => void;
@@ -18,8 +18,8 @@ interface StatementProps {
 }
 
 export const Statement = React.forwardRef<HTMLTextAreaElement, StatementProps>((props, ref) => {
-  const importId = props.statement.importId;
-  const statementId = props.statement.id;
+  const { importId, statementId } = props;
+  const thisImport = useAppSelector((state) => importsSelectors.selectById(state, importId));
   const statementSelectors = useAppSelector((state) => getSelectorsForImportId(state, importId));
   const statement = useAppSelector((state) => statementSelectors!.selectById(state, statementId))!;
 
@@ -144,7 +144,7 @@ export const Statement = React.forwardRef<HTMLTextAreaElement, StatementProps>((
             <Button variant="outline-primary" onClick={onInsertAbove}>Insert Before</Button>
             <Button variant="outline-primary" onClick={onInsertBelow}>Insert After</Button>
             <Button variant="outline-secondary" onClick={toggleDelete}>{statement.deleted ? "Restore" : "Delete"}</Button>
-            <Button variant="outline-primary" onClick={showExecuteModal} disabled={props.database === ""}>Execute</Button>
+            <Button variant="outline-primary" onClick={showExecuteModal} disabled={!thisImport || thisImport.database === ""}>Execute</Button>
           </ButtonGroup>
         </p>
       </Col>

--- a/src/features/imports/components/Statement.tsx
+++ b/src/features/imports/components/Statement.tsx
@@ -5,6 +5,7 @@ import type { ImportIssue } from "../../../common/import";
 import { importsSlice, Statement as StatementType } from "../importsSlice";
 import { modalSlice } from "../../modals/modalSlice";
 import { useAppDispatch } from "../../../app/hooks";
+import { useAddUser } from "../hooks";
 
 interface StatementProps {
   statement: StatementType;
@@ -14,7 +15,6 @@ interface StatementProps {
     handleFixSequence: (statementIdx: number, issueIdentifier: string) => void;
     handleTextAreaChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
     setActiveStatement: () => void;
-    handleAddUser: (user: string) => void;
   }
 }
 
@@ -61,6 +61,8 @@ export const Statement = React.forwardRef<HTMLTextAreaElement, StatementProps>((
     dispatch(modalSlice.actions.showRawSql(statement.cockroach));
   }, [ dispatch, statement.cockroach ]);
 
+  const onAddUser = useAddUser();
+
   const onFixSequence = (statementIdx: number, issueIdentifier: string) =>
     () => props.callbacks.handleFixSequence(statementIdx, issueIdentifier)
 
@@ -94,7 +96,7 @@ export const Statement = React.forwardRef<HTMLTextAreaElement, StatementProps>((
                 <Button variant="outline-info" onClick={onFixSequence(props.idx, issue.id)}>Make UUID</Button>
               ) : ''}
               {issue.type === "missing_user" ? (
-                <Button variant="outline-info" onClick={() => props.callbacks.handleAddUser(issue.id)}>Add user "{issue.id}"</Button>
+                <Button variant="outline-info" onClick={() => onAddUser(issue.id, props.idx, statement.importId, statement)}>Add user "{issue.id}"</Button>
               ) : ''}
             </li>
           )) : ''}

--- a/src/features/imports/components/Statement.tsx
+++ b/src/features/imports/components/Statement.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import { Row, Col, Button, ButtonGroup } from 'react-bootstrap';
 
 import type { ImportIssue } from "../../../common/import";
-import { getSelectorsForImportId, importsSelectors, importsSlice, Statement as StatementType } from "../importsSlice";
+import { getSelectorsForImportId, importsSelectors, importsSlice } from "../importsSlice";
 import { modalSlice } from "../../modals/modalSlice";
 import { useAppDispatch, useAppSelector } from "../../../app/hooks";
 import { useAddUser } from "../hooks";
@@ -75,7 +75,7 @@ export const Statement = React.forwardRef<HTMLTextAreaElement, StatementProps>((
         cockroach: crdbStmt,
       })
     ),
-    [ dispatch, crdbStmt ]
+    [ dispatch, crdbStmt, statement ],
   );
 
   // Overwrite the local statement whenever the <textarea> changes

--- a/src/features/imports/hooks.ts
+++ b/src/features/imports/hooks.ts
@@ -2,16 +2,10 @@ import { useCallback } from "react";
 import { useDispatch } from "react-redux";
 import { importsSlice, Statement } from "./importsSlice";
 
-type AddUserOptions = {
-  importId: string,
-  index: number,
-  username: string,
-};
-
 export function useAddUser() {
   const dispatch = useDispatch();
 
-  return useCallback((username: string, index: number, importId: string, statement?: Statement, ) => {
+  return useCallback((username: string, index: number, importId: string, statement?: Statement) => {
     dispatch(
       importsSlice.actions.insertStatement({
         importId: importId,

--- a/src/features/imports/hooks.ts
+++ b/src/features/imports/hooks.ts
@@ -1,0 +1,43 @@
+import { useCallback } from "react";
+import { useDispatch } from "react-redux";
+import { importsSlice, Statement } from "./importsSlice";
+
+type AddUserOptions = {
+  importId: string,
+  index: number,
+  username: string,
+};
+
+export function useAddUser() {
+  const dispatch = useDispatch();
+
+  return useCallback((username: string, index: number, importId: string, statement?: Statement, ) => {
+    dispatch(
+      importsSlice.actions.insertStatement({
+        importId: importId,
+        index: index,
+        statement: `CREATE USER IF NOT EXISTS "${username}"`,
+      }),
+    );
+
+    dispatch(
+      importsSlice.actions.insertStatement({
+        importId: importId,
+        // Because we're still in the same callback, props.idx hasn't yet updated after adding the "CREATE USER"
+        // statement. Insert the "GRANT" statement below the "CREATE USER" statement, which now has the same ID as
+        // 'props.idx'.
+        index: index + 1,
+        statement: `GRANT admin TO "${username}"`,
+      }),
+    );
+
+    if (statement) {
+      dispatch(
+        importsSlice.actions.clearStatementIssuesByType({
+          statement: statement,
+          issueType: "missing_user"
+        })
+      );
+    }
+  }, [ dispatch ]);
+}

--- a/src/features/imports/importsSlice.ts
+++ b/src/features/imports/importsSlice.ts
@@ -91,6 +91,21 @@ export const importsSlice = createSlice({
         ...nextState.ids.slice(index, nextState.ids.length - 1),
       ];
     },
+    setStatementText(state, action: PayloadAction<{ statement: Statement, original?: string, cockroach?: string }>) {
+      const { statement, original, cockroach } = action.payload;
+      const theImport = state.entities[statement.importId];
+      if (!theImport) {
+        return;
+      }
+
+      const modifiedStatement: Statement = {
+        ...statement,
+        original: original || statement.original,
+        cockroach: cockroach || statement.cockroach,
+      }
+
+      statementsAdapter.setOne(theImport.statements, modifiedStatement);
+    },
     clearStatementIssuesByType(state, action: PayloadAction<{ statement: Statement, issueType: string }>) {
       const { statement, issueType } = action.payload;
       const theImport = state.entities[statement.importId];

--- a/src/features/imports/importsSlice.ts
+++ b/src/features/imports/importsSlice.ts
@@ -67,8 +67,9 @@ export const importsSlice = createSlice({
 
       statementsAdapter.setMany(theImport.statements, modifiedStatements);
     },
-    insertStatement(state, action: PayloadAction<{ importId: string, index: number}>) {
+    insertStatement(state, action: PayloadAction<{ importId: string, index: number, statement?: string}>) {
       const { importId, index } = action.payload;
+      const cockroachStatement = action.payload.statement ?? "";
 
       const theImport = state.entities[importId];
       if (!theImport) {
@@ -79,7 +80,7 @@ export const importsSlice = createSlice({
         importId: importId,
         id: nanoid(),
         original: "-- newly added statement",
-        cockroach: "",
+        cockroach: cockroachStatement,
         deleted: false,
         issues: [],
       };
@@ -89,7 +90,20 @@ export const importsSlice = createSlice({
         statement.id,
         ...nextState.ids.slice(index, nextState.ids.length - 1),
       ];
-    }
+    },
+    clearStatementIssuesByType(state, action: PayloadAction<{ statement: Statement, issueType: string }>) {
+      const { statement, issueType } = action.payload;
+      const theImport = state.entities[statement.importId];
+      if (!theImport) {
+        return;
+      }
+
+      const modifiedStatement = {
+        ...statement,
+        issues: statement.issues.filter(issue => issue.type !== issueType),
+      };
+      statementsAdapter.setOne(theImport.statements, modifiedStatement);
+    },
   },
 });
 

--- a/src/features/modals/modalSlice.ts
+++ b/src/features/modals/modalSlice.ts
@@ -10,6 +10,7 @@ type SqlModal = {
 };
 type ExportModal = {
   kind: "EXPORT",
+  exportText: string,
 };
 type FindReplaceModal = {
   kind: "FIND_REPLACE",
@@ -38,7 +39,7 @@ export const modalSlice = createSlice({
         };
       }
     },
-    showExport: (state) => { state.visibleModal = { kind: "EXPORT" }; },
+    showExport: (state, action: PayloadAction<string>) => { state.visibleModal = { kind: "EXPORT", exportText: action.payload }; },
     showFindReplace: (state) => { state.visibleModal = { kind: "FIND_REPLACE" }; },
     hideAll: (state) => { state.visibleModal = { kind: "NONE" }; }
   },


### PR DESCRIPTION
This brings _almost_ everything into pure redux, with the exception of the `/put` endpoint and a few other transformations (mostly the "convert to UUID" action, which I'm a bit unclear on why that requires a call to the backend).  Beyond that, this is pretty straightforward.  Thanks for the great framework @otan !  This was pretty easy to convert with the structure you'd already laid out 🎉 